### PR TITLE
fix: return thumbnail URL after transcoding

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -880,7 +880,8 @@ app.post('/transcode', upload.single('video'), async (req, res) => {
       duration: totalDuration,
       creator,
       sourceApp,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      ...(thumbnail && { thumbnailUrl: thumbnail })
     });
 
   } catch (err) {


### PR DESCRIPTION
## Summary
- include `thumbnailUrl` in successful `/transcode` responses when a thumbnail is available
- preserve all existing response fields and behavior

## Validation
- `node --check src/server.js`
- `git diff --check`

## Note
- `pnpm test-logs` is currently not runnable because the repository script references the missing `test-logs.js` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Transcoding responses now include a thumbnail URL when one is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->